### PR TITLE
Adapt tag pattern for assest creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+-[a-zA-Z]*"
+      - "[0-9]+.[0-9]+.[0-9]"
 
 jobs:
   github-release:


### PR DESCRIPTION
Assets are currently not built, which is presumably caused by an erroneous pattern in the GitHub build workflow.