### PR TITLE
Fix workflows installing Miniforge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v3
       - uses: conda-incubator/setup-miniconda@v2
-        with: { miniforge-variant: "Mambaforge" }
+        with: { miniforge-variant: "Miniforge3" }
       - name: install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: "${{ matrix.python }}"
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
       - name: install dependencies
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
The latest release of Miniforge does not include a Mambaforge variant.

https://github.com/conda-forge/miniforge/releases

- [ ] Added a news file.

