### PR TITLE
Fix buil workflow to generate db

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   github-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/doc/news/ubuntu-24-04.rst
+++ b/doc/news/ubuntu-24-04.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Fixed ubuntu runner to version 24.04, required for building the database.


### PR DESCRIPTION
the zip was not created during the build of 0.4.0